### PR TITLE
fix: sync package version with npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blen/create-fastapi-app",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Create a FastAPI project with proper tooling in seconds",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, incrementing the package version from `1.0.1` to `1.0.3`.